### PR TITLE
Added relativePath to processString method

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
 Filter.prototype.processFile = function (srcDir, destDir, relativePath) {
   var self = this
   var string = fs.readFileSync(srcDir + '/' + relativePath, { encoding: 'utf8' })
-  return RSVP.Promise.cast(self.processString(string))
+  return RSVP.Promise.cast(self.processString(string, relativePath))
     .then(function (outputString) {
       var outputPath = self.getDestFilePath(relativePath)
       fs.writeFileSync(destDir + '/' + outputPath, outputString, { encoding: 'utf8' })


### PR DESCRIPTION
This allows filters to know where the string in the `processString` method comes from.

A useful example would be code linting. 
Right now a linting library can run a validation over the given string but can't report any useful information on where the dev has to change something to get rid of the reported information.
