### PR TITLE
Allow specifying destDir.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # master
 
+* Add `destDir` to allow specify non-root directory for output.
+
 # 0.1.6
 
 * Copy instead of hardlinking


### PR DESCRIPTION
This allows specifying a destDir to the Filter instance's constructor, and (if present) will allow placing the output into a subdirectory in the generated tree. This is often desirable and can currently be done in two steps with `broccoli-static-compiler`, but a more built-in solution seemed appropriate.

Fixes #7.
