### PR TITLE
Pass along the srcDir for filter plugins that might need it

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
 Filter.prototype.processFile = function (srcDir, destDir, relativePath) {
   var self = this
   var string = fs.readFileSync(srcDir + '/' + relativePath, { encoding: 'utf8' })
-  return Promise.resolve(self.processString(string, relativePath))
+  return Promise.resolve(self.processString(string, relativePath, srcDir))
     .then(function (outputString) {
       var outputPath = self.getDestFilePath(relativePath)
       fs.writeFileSync(destDir + '/' + outputPath, outputString, { encoding: 'utf8' })


### PR DESCRIPTION
For example, my modifications to make broccoli-jade work with include/extend require this: https://github.com/sindresorhus/broccoli-jade/pull/2.

(Edit: unless there is an alternative/better way to do this)