### PR TITLE
Use symlinking

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     "cache"
   ],
   "dependencies": {
-    "quick-temp": "^0.1.0",
-    "mkdirp": "^0.3.5",
-    "rsvp": "^3.0.3",
+    "broccoli-kitchen-sink-helpers": "^0.2.5",
     "broccoli-writer": "^0.1.1",
-    "walk-sync": "^0.1.0",
-    "broccoli-kitchen-sink-helpers": "^0.2.0",
-    "promise-map-series": "^0.2.0"
+    "dir-to-tree": "^0.1.0",
+    "quick-temp": "^0.1.0",
+    "rsvp": "^3.0.3",
+    "symlink-or-copy": "^1.0.0"
   }
 }


### PR DESCRIPTION
I updated this plugin to follow symlinks and to use symlinks itself for all the files that are not filtered.

It intelligently figures out if an entire directory doesn't need filtering and then symlinks the entire directory instead of symlinking each file. This speeds up performance a lot in many cases.


## Benchmarks

### Setup

Setup the [benchmark project](https://github.com/sebastianseilund/benchmark-broccoli-filter). It contains a couple hundred .js files and 100 .hbs files. It resembles a typical Ember app. It's `Brocfile.js` filters all .hbs files to be .js files.

```
git clone git@github.com:sebastianseilund/benchmark-broccoli-filter.git
cd benchmark-broccoli-filter
npm install
```


## Running benchmarks for master

```
rm -rf node_modules/broccoli-filter
npm install https://github.com/broccolijs/broccoli-filter/tarball/master
node benchmark.js
```


## Running benchmarks for this branch

```
rm -rf node_modules/broccoli-filter
npm install https://github.com/sebastianseilund/broccoli-filter/tarball/make-it-so
node benchmark.js
```


### Results

All times are in ms. Lower is better.

| Branch | First build average | Rebuilds average |
| --- | --- | --- |
| master | 168 | 132 |
| make-it-so | 54 | 28 |

`broccoli build` runs 4-5x faster using this branch for the benchmark project.
