### PR TITLE
Use symlinks in broccoli-filter output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var Writer = require('broccoli-writer')
 var helpers = require('broccoli-kitchen-sink-helpers')
 var walkSync = require('walk-sync')
 var mapSeries = require('promise-map-series')
+var symlinkOrCopySync = require('symlink-or-copy').sync
 
 
 module.exports = Filter
@@ -38,8 +39,7 @@ Filter.prototype.write = function (readTree, destDir) {
         if (self.canProcessFile(relativePath)) {
           return self.processAndCacheFile(srcDir, destDir, relativePath)
         } else {
-          helpers.copyPreserveSync(
-            srcDir + '/' + relativePath, destDir + '/' + relativePath)
+          symlinkOrCopySync(srcDir + '/' + relativePath, destDir + '/' + relativePath)
         }
       }
     })
@@ -75,7 +75,7 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
   this._cacheIndex = this._cacheIndex || 0
   var cacheEntry = this._cache[relativePath]
   if (cacheEntry != null && cacheEntry.hash === hash(cacheEntry.inputFiles)) {
-    copyFromCache(cacheEntry)
+    symlinkOrCopyFromCache(cacheEntry)
   } else {
     return Promise.resolve()
       .then(function () {
@@ -98,15 +98,11 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
     }).join(',')
   }
 
-  function copyFromCache (cacheEntry) {
+  function symlinkOrCopyFromCache (cacheEntry) {
     for (var i = 0; i < cacheEntry.outputFiles.length; i++) {
       var dest = destDir + '/' + cacheEntry.outputFiles[i]
       mkdirp.sync(path.dirname(dest))
-      // We may be able to link as an optimization here, because we control
-      // the cache directory; we need to be 100% sure though that we don't try
-      // to hardlink symlinks, as that can lead to directory hardlinks on OS X
-      helpers.copyPreserveSync(
-        self.getCacheDir() + '/' + cacheEntry.cacheFiles[i], dest)
+      symlinkOrCopySync(self.getCacheDir() + '/' + cacheEntry.cacheFiles[i], dest)
     }
   }
 
@@ -119,6 +115,7 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
     for (var i = 0; i < cacheEntry.outputFiles.length; i++) {
       var cacheFile = (self._cacheIndex++) + ''
       cacheEntry.cacheFiles.push(cacheFile)
+
       helpers.copyPreserveSync(
         destDir + '/' + cacheEntry.outputFiles[i],
         self.getCacheDir() + '/' + cacheFile)

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "cache"
   ],
   "dependencies": {
-    "quick-temp": "^0.1.0",
-    "mkdirp": "^0.3.5",
-    "rsvp": "^3.0.3",
-    "broccoli-writer": "^0.1.1",
-    "walk-sync": "^0.1.0",
     "broccoli-kitchen-sink-helpers": "^0.2.5",
-    "promise-map-series": "^0.2.0"
+    "broccoli-writer": "^0.1.1",
+    "mkdirp": "^0.3.5",
+    "promise-map-series": "^0.2.0",
+    "quick-temp": "^0.1.0",
+    "rsvp": "^3.0.3",
+    "symlink-or-copy": "^1.0.0",
+    "walk-sync": "^0.1.3"
   }
 }


### PR DESCRIPTION
This is a bit of a smaller change to introduce symlinking initially, before the additional optimization that #11 introduces.