### PR TITLE
Update helpers to latests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rsvp": "^3.0.3",
     "broccoli-writer": "^0.1.1",
     "walk-sync": "^0.1.0",
-    "broccoli-kitchen-sink-helpers": "^0.2.0",
+    "broccoli-kitchen-sink-helpers": "^0.2.5",
     "promise-map-series": "^0.2.0"
   }
 }


### PR DESCRIPTION
Without this change, NPM is using 0.2.0 for this package (even though 0.2.5 is more recent and matches the floating dep constraint).

When the current version of broccoli-filter is used with a directory that contains symlinks (like something from static-compiler or merge-trees), and kitchen-sink-helpers less than 0.2.5 is used, none of the symlinks can use cache (since we are comparing hashes of the symlinks which are recreated for each built).

@joliss - Could you please release a 0.1.7 with this change?
