### PR TITLE
Throw on undefined inputTree

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@ module.exports = Filter
 Filter.prototype = Object.create(Writer.prototype)
 Filter.prototype.constructor = Filter
 function Filter (inputTree, options) {
+  if (!inputTree) {
+    throw new Error('broccoli-filter must be passed an inputTree, instead it received `undefined`');
+  }
   this.inputTree = inputTree
   options = options || {}
   if (options.extensions != null) this.extensions = options.extensions


### PR DESCRIPTION
When an `undefined` `inputTree` is allowed to pass into a filter, exceptions may be raised from deep within the bowels of RSVP. Instead, let's catch this mistake up-front and throw during the constructor.