### PR TITLE
ProccessFile encoding raw by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
 
 Filter.prototype.processFile = function (srcDir, destDir, relativePath) {
   var self = this
-  var inputEncoding = (this.inputEncoding === undefined) ? 'utf8' : this.inputEncoding
+  var inputEncoding = (this.inputEncoding === undefined) ? null : this.inputEncoding
   var outputEncoding = (this.outputEncoding === undefined) ? 'utf8' : this.outputEncoding
   var string = fs.readFileSync(srcDir + '/' + relativePath, { encoding: inputEncoding })
   return Promise.resolve(self.processString(string, relativePath))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broccoli-filter",
   "description": "Helper base class for Broccoli plugins that map input files into output files one-to-one",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "author": "Jo Liss <joliss42@gmail.com>",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Ran into an issue with broccoli-gzip where the encoding is not passed, and I'm attempting to gzip text files along with binary files.  Since the binary files by default were being treated as utf8, the gzip output is corrupt.  I suggest that by default we treat the inputEncoding for files as raw to support manipulation of binary files.