### PR TITLE
[Ergonomics] Provide a better error message for proccessString

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,3 +159,7 @@ Filter.prototype.processFile = function (srcDir, destDir, relativePath) {
       fs.writeFileSync(destDir + '/' + outputPath, outputString, { encoding: outputEncoding })
     })
 }
+
+Filter.prototype.processString = function() {
+  throw new Error('When subclassing broccoli-filter you must implement the `processString()` method.');
+};


### PR DESCRIPTION
When people are just getting started writing broccoli plugins they don't know what methods they need to implemented in the subclass. This commit adds a more friendly error message to proccessString, letting developers know they need to implement it.