### PR TITLE
Extract out functions nested inside of processAndCacheFile to the prototype.

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
   this._cache = this._cache || {}
   this._cacheIndex = this._cacheIndex || 0
   var cacheEntry = this._cache[relativePath]
-  if (cacheEntry != null && cacheEntry.hash === self.hash(cacheEntry.inputFiles, srcDir)) {
-    this.symlinkOrCopyFromCache(cacheEntry, destDir)
+  if (cacheEntry != null && cacheEntry.hash === self._hash(cacheEntry.inputFiles, srcDir)) {
+    this._symlinkOrCopyFromCache(cacheEntry, destDir)
   } else {
     return Promise.resolve()
       .then(function () {
@@ -91,19 +91,19 @@ Filter.prototype.processAndCacheFile = function (srcDir, destDir, relativePath) 
         throw err
       })
       .then(function (cacheInfo) {
-        self.copyToCache(cacheInfo, srcDir, relativePath, destDir)
+        self._copyToCache(cacheInfo, srcDir, relativePath, destDir)
       })
   }
 
 }
 
-Filter.prototype.hash = function (filePaths, srcDir) {
+Filter.prototype._hash = function (filePaths, srcDir) {
   return filePaths.map(function (filePath) {
     return helpers.hashTree(srcDir + '/' + filePath)
   }).join(',')
 }
 
-Filter.prototype.symlinkOrCopyFromCache = function (cacheEntry, destDir) {
+Filter.prototype._symlinkOrCopyFromCache = function (cacheEntry, destDir) {
   for (var i = 0; i < cacheEntry.outputFiles.length; i++) {
     var dest = destDir + '/' + cacheEntry.outputFiles[i]
     mkdirp.sync(path.dirname(dest))
@@ -111,7 +111,7 @@ Filter.prototype.symlinkOrCopyFromCache = function (cacheEntry, destDir) {
   }
 }
 
-Filter.prototype.copyToCache = function (cacheInfo, srcDir, relativePath, destDir) {
+Filter.prototype._copyToCache = function (cacheInfo, srcDir, relativePath, destDir) {
   var cacheEntry = {
     inputFiles: (cacheInfo || {}).inputFiles || [relativePath],
     outputFiles: (cacheInfo || {}).outputFiles || [this.getDestFilePath(relativePath)],
@@ -125,7 +125,7 @@ Filter.prototype.copyToCache = function (cacheInfo, srcDir, relativePath, destDi
       destDir + '/' + cacheEntry.outputFiles[i],
       this.getCacheDir() + '/' + cacheFile)
   }
-  cacheEntry.hash = this.hash(cacheEntry.inputFiles, srcDir)
+  cacheEntry.hash = this._hash(cacheEntry.inputFiles, srcDir)
   this._cache[relativePath] = cacheEntry
 }
 


### PR DESCRIPTION
This provides for more flexibility for subclasses, especially if it needs to do something where it would be helpful to reuse one of these functions.

I came to this via https://github.com/broccolijs/broccoli-filter/compare/master...timmfin:symlink-identical-output, where I wanted to make processFile _not_ write a new file to disk when processString returned the same exact output as input it was sent (particularly useful for filters that _might_ only change the content, but you don't know that until the file is read).

However, I realized that may be too significant of a change to make for existing plugins. So instead, if these previously hidden functions were more available to subclasses, it would be trivial to implement the “symlink indention output” functionality via the subclass (among all sorts of other things).

Tested against the tests contained in both https://github.com/broccolijs/broccoli-filter/pull/22 and https://github.com/broccolijs/broccoli-filter/pull/23 :)