### PR TITLE
cut FS activity down dramatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "copy-dereference": "^1.0.0",
     "debug": "^2.2.0",
     "mkdirp": "^0.5.1",
+    "mkdirp-bulk": "^1.0.0",
     "promise-map-series": "^0.2.1",
     "rsvp": "^3.0.18",
     "symlink-or-copy": "^1.0.1",


### PR DESCRIPTION
- better logging
- use mkdir-batch to group mkdirs together and do the less overall work (don’t attempt to re-create the same dirs repeatedly)
- rather then writing to output and then doing a copyDereferenceSync to the cache, we just write to cache and link to output
- [ ] fix windows
- [ ] tests

fixes #32
