### PR TITLE
one-to-many file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,10 @@ var node = new Awk('docs', 'ES6', 'ECMAScript 2015');
 
 module.exports = node;
 ```
+
+## Converting from `broccoli-filter`
+
+1. Change your require to `broccoli-multi-filter`.
+2. Make sure tests still pass.
+3. Add the `addOutputFile` argument to your implementation of `processString`.
+4. Call `addOutputFile` to generate any additional files you need to generate.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ class MultiFilter {
 
   /**
    * Abstract method `processString`: must be implemented on subclasses of
-   * Filter.
+   * MultiFilter.
    * 
    * The `addOutputFile` callback accepts two arguments `(contents: string, outputRelativeFilename: string)`
    * this file must be called to generate any side-effect files and make sure they are handled properly with
@@ -35,7 +35,7 @@ class MultiFilter {
    * `relativePath` to process the file with `processString`. Return a
    * different path to process the file with `processString` and rename it.
    *
-   * By default, if the options passed into the `Filter` constructor contain a
+   * By default, if the options passed into the `MultiFilter` constructor contain a
    * property `extensions`, and `targetExtension` is supplied, the first matching
    * extension in the list is replaced with the `targetExtension` option's value.
    */

--- a/index.js
+++ b/index.js
@@ -117,9 +117,29 @@ Filter.prototype.processAndCacheFile =
     this._debug('cache prime: %s', relativePath);
   }
 
+  cacheEntry = {
+    hash: hash(srcDir, relativePath),
+    inputFile: relativePath,
+    results: [
+      {
+        output: destDir + '/' + outputRelativeFile,
+        cache: self.cachePath + '/' + outputRelativeFile
+      }
+    ]
+  };
+
+  function addOutputFile(contents, outputRelativeFilename) {
+    var outputPath = path.join(destDir, outputRelativeFilename);
+    fs.writeFileSync(outputPath, contents, { encoding: self.outputEncoding });
+    cacheEntry.results.push({
+      output: destDir + '/' + outputRelativeFilename,
+      cache: self.cachePath + '/' + outputRelativeFilename
+    });
+  }
+
   return Promise.resolve().
       then(function asyncProcessFile() {
-        return self.processFile(srcDir, destDir, relativePath);
+        return self.processFile(srcDir, destDir, relativePath, addOutputFile);
       }).
       then(copyToCache,
       // TODO(@caitp): error wrapper is for API compat, but is not particularly
@@ -133,27 +153,22 @@ Filter.prototype.processAndCacheFile =
       })
 
   function copyToCache() {
-    var entry = {
-      hash: hash(srcDir, relativePath),
-      inputFile: relativePath,
-      outputFile: destDir + '/' + outputRelativeFile,
-      cacheFile: self.cachePath + '/' + outputRelativeFile
-    };
+    cacheEntry.results.forEach(function(result) {
+      if (fs.existsSync(result.cache)) {
+        fs.unlinkSync(result.cache);
+      } else {
+        mkdirp.sync(path.dirname(result.cache));
+      }
 
-    if (fs.existsSync(entry.cacheFile)) {
-      fs.unlinkSync(entry.cacheFile);
-    } else {
-      mkdirp.sync(path.dirname(entry.cacheFile));
-    }
+      copyDereferenceSync(result.output, result.cache);
+    });
 
-    copyDereferenceSync(entry.outputFile, entry.cacheFile);
-
-    return self._cache.set(relativePath, entry);
+    return self._cache.set(relativePath, cacheEntry);
   }
 };
 
 Filter.prototype.processFile =
-    function processFile(srcDir, destDir, relativePath) {
+    function processFile(srcDir, destDir, relativePath, addOutputFile) {
   var self = this;
   var inputEncoding = this.inputEncoding;
   var outputEncoding = this.outputEncoding;
@@ -162,7 +177,7 @@ Filter.prototype.processFile =
   var contents = fs.readFileSync(
       srcDir + '/' + relativePath, { encoding: inputEncoding });
 
-  return Promise.resolve(this.processString(contents, relativePath)).
+  return Promise.resolve(this.processString(contents, relativePath, addOutputFile)).
       then(function asyncOutputFilteredFile(outputString) {
         var outputPath = self.getDestFilePath(relativePath);
         if (outputPath == null) {
@@ -177,7 +192,7 @@ Filter.prototype.processFile =
 };
 
 Filter.prototype.processString =
-    function unimplementedProcessString(contents, relativePath) {
+    function unimplementedProcessString(contents, relativePath, addOutputFile) {
   throw new Error(
       'When subclassing broccoli-filter you must implement the ' +
       '`processString()` method.');
@@ -199,7 +214,9 @@ function hash(src, filePath) {
 }
 
 function symlinkOrCopyFromCache(entry, dest, relativePath) {
-  mkdirp.sync(path.dirname(entry.outputFile));
+  entry.results.forEach(function(result) {
+    mkdirp.sync(path.dirname(result.output));
 
-  symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath);
+    symlinkOrCopySync(result.cache, dest + '/' + relativePath);
+  });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "broccoli-multi-filter",
   "description": "Helper base class for Broccoli plugins that map input files into output files one-to-one",
-  "version": "1.2.3",
+  "version": "1.2.3-multi.0",
   "author": [
     "Jo Liss <joliss42@gmail.com>",
     "Caitlin Potter <caitpotter88@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "broccoli-filter",
+  "name": "broccoli-multi-filter",
   "description": "Helper base class for Broccoli plugins that map input files into output files one-to-one",
   "version": "1.2.3",
   "author": [
     "Jo Liss <joliss42@gmail.com>",
-    "Caitlin Potter <caitpotter88@gmail.com>"
+    "Caitlin Potter <caitpotter88@gmail.com>",
+    "Chris Eppstein <chris@eppsteins.net>"
   ],
   "main": "index.js",
   "scripts": {
@@ -17,12 +18,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/broccolijs/broccoli-filter"
+    "url": "https://github.com/chriseppstein/broccoli-multi-filter"
   },
   "keywords": [
     "broccoli-helper",
     "filter",
-    "cache"
+    "cache",
+    "broccoli-filter"
   ],
   "dependencies": {
     "broccoli-kitchen-sink-helpers": "^0.2.7",

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,18 @@ function IncompleteFilter(inputTree, options) {
 
 inherits(IncompleteFilter, Filter);
 
+function KeepOriginalFilter(inputTree, options) {
+  if (!this) return new KeepOriginalFilter(inputTree, options);
+  Filter.call(this, inputTree, options);
+}
+inherits(KeepOriginalFilter, Filter);
+
+KeepOriginalFilter.prototype.processString = function(contents, relativePath, addOutputFile) {
+  addOutputFile(contents, relativePath + ".original");
+  return contents;
+}
+KeepOriginalFilter.extensions = ["js"];
+
 describe('Filter', function() {
   function makeBuilder(plugin, dir, prepSubject) {
     return makeTestHelper({
@@ -73,7 +85,7 @@ describe('Filter', function() {
   function write(relativePath, contents, encoding) {
     encoding = encoding === void 0 ? 'utf8' : encoding;
     mkdirp.sync(path.dirname(relativePath));
-    fs.writeFileSync(relativePath, contents, {
+    fs.writKeepOriginalFiltereFileSync(relativePath, contents, {
       encoding: encoding
     });
   }
@@ -319,6 +331,35 @@ describe('Filter', function() {
       }).then(function() {
         expect(fs.writeFileSync.calledWith(path.join(process.cwd(), 'a', 'foo.js'), "Nicest dogs in need of homes")).to.eql(false);
       });
+    });
+  });
+});
+
+describe('MultiFilter', function() {
+  function read(relativePath, encoding) {
+    encoding = encoding === void 0 ? 'utf8' : encoding;
+    return fs.readFileSync(relativePath, encoding);
+  }
+
+  function makeBuilder(plugin, dir, prepSubject) {
+    return makeTestHelper({
+      subject: plugin,
+      fixturePath: dir,
+      prepSubject: prepSubject
+    });
+  }
+
+  afterEach(function() {
+    return cleanupBuilders();
+  });
+
+  var noPrep = function(subject) { return subject; };
+  it("should generate two files per input file", function() {
+    var builder = makeBuilder(KeepOriginalFilter, fixturePath, noPrep);
+    return builder('dir',{}).then(function(results) {
+      var kof = results.subject;
+      expect(read(results.directory + '/a/foo.js')).
+          to.equal(read(results.directory + '/a/foo.js.original'));
     });
   });
 });


### PR DESCRIPTION
This is currently published as a fork, but if the direction here is something folks like, I will be happy to re-work this PR into something mergable. For now, I'd like to get feedback. Specifically, I find that the  `targetExtension` property, probably doesn't make as much sense now but I'm not sure how to maintain backwards compat otherwise.

From the original README:

**Q**: Can this help with compilers that are almost 1:1, like a minifier that takes
-a `.js` and `.js.map` file and outputs a `.js` and `.js.map` file?

**A**: I don't know yet how to implement this and still have the API look beautiful. We also have to make sure that caching works correctly, as we have to invalidate if either the `.js` or the `.js.map` file changes.

I'm not sure if this API is considered "beautiful" (such is in the eye of the beholder) but it is identical to the original API until you need to add a second output file at which point you just need to accept a new argument and call a callback with the string and the relative filename. This works with caching.