### PR TITLE
error thrown when array of trees is passed to constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ function Filter(inputTree, options) {
     throw new TypeError('Filter is an abstract class and must be sub-classed');
   }
 
+  // Validate that a single node was passed in
+  if (Array.isArray(inputTree)) {
+    throw new Error('inputTree should be a single tree, array was passed');
+  }
+
   var name = 'broccoli-filter:' + (this.constructor.name);
   if (this.description) {
     name += ' > [' + this.description + ']';

--- a/test/test.js
+++ b/test/test.js
@@ -112,6 +112,13 @@ describe('Filter', function() {
   });
 
 
+  it('should throw if constructor is passed array of trees', function() {
+    expect(function() {
+      new IncompleteFilter(['.']);
+    }).to.throw(Error, /array was passed/);
+  });
+
+
   it('should throw if `processString` is not implemented', function() {
     expect(function() {
       new IncompleteFilter('.').processString('foo', 'fake_path');


### PR DESCRIPTION
Ran into this today where I was passing in an array of trees (as one generally does with many broccoli plugins) and getting a cryptic error. It wasn't immediately obvious that this works on a singe tree until after a fair bit of digging. Added a validation for that to hopefully prevent such confusion in the future.