### PR TITLE
Avoid calling `mkdirp` for every file copied from cache.

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,7 +199,11 @@ function hash(src, filePath) {
 }
 
 function symlinkOrCopyFromCache(entry, dest, relativePath) {
-  mkdirp.sync(path.dirname(entry.outputFile));
-
-  symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath);
+  try {
+    symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath);
+  } catch(err) {
+    // assume that the destination directory is missing create it and retry
+    mkdirp.sync(path.dirname(entry.outputFile))
+    symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath)
+  }
 }

--- a/index.js
+++ b/index.js
@@ -202,8 +202,12 @@ function symlinkOrCopyFromCache(entry, dest, relativePath) {
   try {
     symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath);
   } catch(err) {
-    // assume that the destination directory is missing create it and retry
-    mkdirp.sync(path.dirname(entry.outputFile))
-    symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath)
+    if (err.code === 'ENOENT') {
+      // assume that the destination directory is missing create it and retry
+      mkdirp.sync(path.dirname(entry.outputFile))
+      symlinkOrCopySync(entry.cacheFile, dest + '/' + relativePath)
+    } else {
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
This updates `symlinkOrCopyFromCache` to avoid eagerly calling `mkdirp.sync`, and now only calls it if an error occurs.

We want to avoid `mkdirp` if possible, since it does extra I/O for every copy from cache operation when most likely the directory is already created (this is essentially assuming that the majority of directories have at least 2 files in them).

One way to visualize the cost of calling `mkdirp` eagerly is to look at its default implementation (pseudo code):

```js
function sync(dirPath) {
  try {
    fs.mkdirSync(dirPath);
  } catch(err0) {
    if (err0.code === 'ENOENT') {
      sync(path.dirname(dirPath)
      sync(dirPath);
    }
    var stat;
    try {
      stat = fs.statSync(dirPath);
    } catch(err1) {
      throw err0;
    }

    if (!stat.isDirectory()) { throw err0; }
  }
}
```