### PR TITLE
Allow null value for inputEncoding and outputEncoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,10 +39,12 @@ function Filter(inputTree, options) {
       this.extensions = options.extensions;
     if (options.targetExtension != null)
       this.targetExtension = options.targetExtension;
-    if (options.inputEncoding != null)
-      this.inputEncoding = options.inputEncoding;
-    if (options.outputEncoding != null)
-      this.outputEncoding = options.outputEncoding;
+    
+    // not checking the value of options.inputEncoding or options.outputEncoding
+    // because setting null values is allowed as per docs:
+    // For binary files, pass null to receive a Buffer object in processString
+    this.inputEncoding = options.inputEncoding;
+    this.outputEncoding = options.outputEncoding;
   }
 
   this._cache = new Cache();


### PR DESCRIPTION
## Problem
Cannot receive buffers in processString

## Solution
Do not check the value of **options.inputEncoding** and **options.outputEncoding** in constructor of Plugin before assigning it. If any of both options is undefined, default value **utf8** will be assigned anyways before calling **readFileSync**.

Fixes #47 