### PR TITLE
Added ability to exclude file from build by returning falsy value

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,11 @@ Filter.prototype.processAndCacheFile =
       then(function asyncProcessFile() {
         return self.processFile(srcDir, destDir, relativePath);
       }).
-      then(copyToCache,
+      then(function checkIfCacheNecessary(outputPath) {
+        if (outputPath) {
+          return copyToCache();
+        }
+      },
       // TODO(@caitp): error wrapper is for API compat, but is not particularly
       // useful.
       // istanbul ignore next
@@ -164,6 +168,9 @@ Filter.prototype.processFile =
 
   return Promise.resolve(this.processString(contents, relativePath)).
       then(function asyncOutputFilteredFile(outputString) {
+        if (!outputString) {
+          return;
+        }
         var outputPath = self.getDestFilePath(relativePath);
         if (outputPath == null) {
           throw new Error('canProcessFile("' + relativePath + '") is true, but getDestFilePath("' + relativePath + '") is null');
@@ -173,6 +180,7 @@ Filter.prototype.processFile =
         fs.writeFileSync(outputPath, outputString, {
           encoding: outputEncoding
         });
+        return outputPath;
       });
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -172,6 +172,31 @@ describe('Filter', function() {
     });
   });
 
+  it('should remove file when processString returns a falsy value', 
+    function() {
+      function RemovingFilter(inputTree, options) {
+        if (!this) return new RemovingFilter(inputTree, options);
+        Filter.call(this, inputTree, options);
+      }
+
+      inherits(RemovingFilter, Filter);
+
+      RemovingFilter.prototype.processString = function(content) {
+        return "Dogs... who needs dogs?" !== content;
+      }
+
+      var builder = makeBuilder(RemovingFilter, fixturePath, function(awk) {
+        return awk;
+      });
+
+      return builder('dir').then(function(results) {
+        expect(existsSync(results.directory + '/a/README.md')).to.be.true;
+        expect(existsSync(results.directory + '/a/foo.js')).to.be.true;
+        expect(existsSync(results.directory + '/a/bar/bar.js')).to.be.false;
+      });
+    }
+  );
+
   it('should complain if canProcessFile is true but getDestFilePath is null',
       function() {
     var builder = makeBuilder(ReplaceFilter, fixturePath, function(awk) {
@@ -321,4 +346,5 @@ describe('Filter', function() {
       });
     });
   });
+
 });


### PR DESCRIPTION
This PR makes broccoli-filter behave like `Array.prototype.filter` - if `this.processString` returns a falsy value then the file will be excluded from the tree.